### PR TITLE
Version 1.1.8

### DIFF
--- a/nhrrob-options-table-manager.php
+++ b/nhrrob-options-table-manager.php
@@ -5,7 +5,7 @@
  * Description: Clean DataTable view of wp-options table to make decisions and boost your site performance!
  * Author: Nazmul Hasan Robin
  * Author URI: https://profiles.wordpress.org/nhrrob/
- * Version: 1.1.7
+ * Version: 1.1.8
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Text Domain: nhrrob-options-table-manager
@@ -27,7 +27,7 @@ final class Nhrotm_Options_Table_Manager {
      *
      * @var string
      */
-    const nhrotm_version = '1.1.7';
+    const nhrotm_version = '1.1.8';
 
     /**
      * Class construcotr

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: nhrrob  
 Tags: wp options, wp_options, transients, usermeta, development  
 Requires at least: 6.0  
-Tested up to: 6.8  
+Tested up to: 6.9
 Requires PHP: 7.4  
-Stable tag: 1.1.7
+Stable tag: 1.1.8
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -84,6 +84,10 @@ Not yet, but this feature is coming soon!
 6. Options usage analytics
 
 == Changelog ==
+
+= 1.1.8 - 30/11/2025 =
+- WordPress tested up to version is updated to 6.9
+- Few minor bug fixing & improvements
 
 = 1.1.7 - 28/03/2025 =
 - Added: Column search feature


### PR DESCRIPTION
= 1.1.8 - 30/11/2025 =
- WordPress tested up to version is updated to 6.9
- Few minor bug fixing & improvements