### PR TITLE
Release 1.4.2: Database repair and stability fix

### DIFF
--- a/.ai/skills/release_plugin.md
+++ b/.ai/skills/release_plugin.md
@@ -53,6 +53,10 @@ git merge staging
    git tag -a vX.Y.Z -m "Release version X.Y.Z"
    git push origin vX.Y.Z
    ```
+4. **Publish GitHub Release**:
+   ```bash
+   gh release create vX.Y.Z --title "X.Y.Z" --notes "Changelog description here"
+   ```
 
 ## Step 5: Post-Release Sync
 Ensure all development branches are in sync with the new release.

--- a/includes/Managers/HistoryManager.php
+++ b/includes/Managers/HistoryManager.php
@@ -70,6 +70,11 @@ class HistoryManager
             $old_value = maybe_serialize($old_value);
         }
 
+        // Ensure table exists (lazy creation)
+        if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table)) !== $table) {
+            $this->create_table();
+        }
+
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Plugin-specific history tracking
         return $wpdb->insert(
             $table,

--- a/nhrrob-options-table-manager.php
+++ b/nhrrob-options-table-manager.php
@@ -5,7 +5,7 @@
  * Description: Optimize WordPress with Advanced Option History, Autoload Health Checks, and Automated Cleanup. Boost performance by reducing database bloat.
  * Author: Nazmul Hasan Robin
  * Author URI: https://profiles.wordpress.org/nhrrob/
- * Version: 1.4.1
+ * Version: 1.4.2
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Text Domain: nhrrob-options-table-manager
@@ -29,7 +29,7 @@ final class Nhrotm_Options_Table_Manager
      *
      * @var string
      */
-    const nhrotm_version = '1.4.1';
+    const nhrotm_version = '1.4.2';
 
     /**
      * Class construcotr

--- a/nhrrob-options-table-manager.php
+++ b/nhrrob-options-table-manager.php
@@ -114,6 +114,7 @@ final class Nhrotm_Options_Table_Manager
         add_action('nhrotm_daily_history_prune', [$this, 'run_history_prune']);
 
         new Nhrotm\OptionsTableManager\Assets();
+        $this->check_version();
 
         if (defined('DOING_AJAX') && DOING_AJAX) {
             new Nhrotm\OptionsTableManager\Ajax\AjaxHandler();
@@ -125,6 +126,23 @@ final class Nhrotm_Options_Table_Manager
 
         if (is_admin()) {
             new Nhrotm\OptionsTableManager\Admin();
+        }
+    }
+
+    /**
+     * Check if the plugin version has changed and run updates
+     * 
+     * @return void
+     */
+    public function check_version()
+    {
+        $stored_version = get_option('nhrotm_version', '1.0.0');
+
+        if (version_compare($stored_version, self::nhrotm_version, '<')) {
+            $history_manager = new \Nhrotm\OptionsTableManager\Managers\HistoryManager();
+            $history_manager->create_table();
+
+            update_option('nhrotm_version', self::nhrotm_version);
         }
     }
 

--- a/nhrrob-options-table-manager.php
+++ b/nhrrob-options-table-manager.php
@@ -114,7 +114,6 @@ final class Nhrotm_Options_Table_Manager
         add_action('nhrotm_daily_history_prune', [$this, 'run_history_prune']);
 
         new Nhrotm\OptionsTableManager\Assets();
-        $this->check_version();
 
         if (defined('DOING_AJAX') && DOING_AJAX) {
             new Nhrotm\OptionsTableManager\Ajax\AjaxHandler();
@@ -126,23 +125,6 @@ final class Nhrotm_Options_Table_Manager
 
         if (is_admin()) {
             new Nhrotm\OptionsTableManager\Admin();
-        }
-    }
-
-    /**
-     * Check if the plugin version has changed and run updates
-     * 
-     * @return void
-     */
-    public function check_version()
-    {
-        $stored_version = get_option('nhrotm_version', '1.0.0');
-
-        if (version_compare($stored_version, self::nhrotm_version, '<')) {
-            $history_manager = new \Nhrotm\OptionsTableManager\Managers\HistoryManager();
-            $history_manager->create_table();
-
-            update_option('nhrotm_version', self::nhrotm_version);
         }
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: wp_options, transients, usermeta, optimize, database-optimization
 Requires at least: 6.0  
 Tested up to: 7.0
 Requires PHP: 7.4  
-Stable tag: 1.4.1
+Stable tag: 1.4.2
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -88,6 +88,9 @@ Yes! We have an automated daily cleanup feature and a manual delete button.
 6. Options usage analytics
 
 == Changelog ==
+
+= 1.4.2 - 09/05/2026 =
+- Fixed: Database error when history table was missing; added lazy table creation logic.
 
 = 1.4.1 - 09/05/2026 =
 - Few minor bug fixes & improvements


### PR DESCRIPTION
Bumping version to 1.4.2. Fixes database error when the history table is missing by adding lazy-creation logic.